### PR TITLE
CSS: fix menu layout on older mobile devices

### DIFF
--- a/style.css
+++ b/style.css
@@ -435,6 +435,10 @@ article time {
   right: .5em;
   z-index: 4;
 }
+/* ------- Mobile ------- */
+@media(max-width:540px) {
+  nav { width: 100%; }
+}
 
 /* ------- Print ------- */
 


### PR DESCRIPTION
The current `flexbox` styling (wrap specifically) doesn't work 100% as intended on older versions of Safari on iOS (see screenshot below). This minor update defines the `nav` element to properly render under the title.

### Issue (left), Fixed (right)

<div style="display:flex;">
<img src="https://user-images.githubusercontent.com/1873938/100105963-f09e9080-2e35-11eb-93b3-88036d47eda8.PNG" width="350"">
<img src="https://user-images.githubusercontent.com/1873938/100106765-f47ee280-2e36-11eb-829f-4d3df98038bc.PNG" width="350">
</div>
